### PR TITLE
Add security to printing of Net::SSH::Simple::Error

### DIFF
--- a/lib/net/ssh/simple.rb
+++ b/lib/net/ssh/simple.rb
@@ -693,7 +693,7 @@ module Net
         end
 
         def to_s
-          "#{@wrapped} @ #{@result}"
+          @wrapped.to_s
         end
       end
 


### PR DESCRIPTION
Have human readable version of Net::SSH::Simple::Error not print the Net:SSH::Simple::Result as the opts stored in Result may lead to leaked credentials if the error message is logged or emailed anywhere.
