### PR TITLE
Bump hashie version

### DIFF
--- a/net-ssh-simple.gemspec
+++ b/net-ssh-simple.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "net-ssh", "= 3.2.0"
   s.add_dependency "net-scp", "= 1.2.1"
   s.add_dependency "blockenspiel", "= 0.5.0"
-  s.add_dependency "hashie", "= 3.4.6"
+  s.add_dependency "hashie", "< 4"
 
   s.add_development_dependency "rake", "~> 10.4.2"
   s.add_development_dependency "rspec", "= 2.14.1"


### PR DESCRIPTION
The hashie version in this gem is not compatible with the version found in the omniauth gem we use, could you please bump it? Below 4 should be fine right?
```
    net-ssh-simple was resolved to 1.6.17, which depends on
      hashie (= 3.4.6)

    omniauth was resolved to 1.5.0, which depends on
      hashie (< 4, ~> 3.5.0)
```