### PR TITLE
Relax dependencies

### DIFF
--- a/lib/net/ssh/simple/version.rb
+++ b/lib/net/ssh/simple/version.rb
@@ -1,7 +1,7 @@
 module Net
   module SSH
     class Simple
-      VERSION = "1.6.18"
+      VERSION = "1.6.19"
     end
   end
 end

--- a/net-ssh-simple.gemspec
+++ b/net-ssh-simple.gemspec
@@ -13,13 +13,13 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.2'
 
-  s.add_dependency "net-ssh", "= 4.0.1"
-  s.add_dependency "net-scp", "= 1.2.1"
-  s.add_dependency "blockenspiel", "= 0.5.0"
-  s.add_dependency "hashie", "= 3.5.3"
+  s.add_dependency "net-ssh", "~> 4.0.1"
+  s.add_dependency "net-scp", "~> 1.2.1"
+  s.add_dependency "blockenspiel", "~> 0.5.0"
+  s.add_dependency "hashie", "~> 3.5.3"
 
   s.add_development_dependency "rake", "~> 10.4.2"
-  s.add_development_dependency "rspec", "= 2.14.1"
+  s.add_development_dependency "rspec", "~> 2.14.1"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "yard", "~> 0.8.2"
   s.add_development_dependency "bump"


### PR DESCRIPTION
I think that it's safe to relax gems dependencies. For instance, big changes between hashie 3.5.3 and 3.5.5 are not expected. The same applies to the rest of gems.

Currently I'm maintaining an RPM package for openSUSE and, everytime a dependency is updated, the package gets broken. Hard dependencies are OK when you're developing an application, but for libraries I rather prefer specifing a range. Yehuda Katz wrote an [interesting article](http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/) about the roles of .gemspec and Gemfile some years ago.